### PR TITLE
Change equality operator to work with zsh

### DIFF
--- a/updateGo.sh
+++ b/updateGo.sh
@@ -93,7 +93,7 @@ sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
 echo "Updating PATH to include /usr/local/go/bin..."
 PROFILE_FILE=""
 
-if [ "$OS" == "darwin" ]; then
+if [ "$OS" = "darwin" ]; then
   if [ -f ~/.zshrc ]; then
     PROFILE_FILE=~/.zshrc
   elif [ -f ~/.bash_profile ]; then


### PR DESCRIPTION
Fixes #1 

Without truly understanding it, changing the equality to `=` seems to please ZSH.