### PR TITLE
Add more error handling, send error messages to stderr, & add ~/go/bin to profile

### DIFF
--- a/updateGo.sh
+++ b/updateGo.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # Function to print usage
 usage() {
-  echo "Usage: $0 <OS> <architecture> <version>"
-  echo "Example: $0 linux amd64 1.22.5"
+  echo "Usage: $0 <OS> <architecture> <version>" >&2
+  echo "Example: $0 linux amd64 1.22.5" >&2
   exit 1
 }
 
@@ -54,7 +54,7 @@ case $OS in
     OS="darwin"
     ;;
   *)
-    echo "Unsupported OS: $OS"
+    echo "Unsupported OS: $OS" >&2
     usage
     ;;
 esac
@@ -68,7 +68,7 @@ case $ARCH in
     ARCH="amd64"
     ;;
   *)
-    echo "Unsupported architecture: $ARCH"
+    echo "Unsupported architecture: $ARCH" >&2
     usage
     ;;
 esac
@@ -83,7 +83,7 @@ echo "Downloading Go version ${VERSION} from ${URL}..."
 wget $URL -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
 WGET_RESULT=$?
 if [ $WGET_RESULT != 0 ]; then
-  echo "Error: wget exited with code ${WGET_RESULT}"
+  echo "Error: wget exited with code ${WGET_RESULT}" >&2
   exit 1
 fi
 

--- a/updateGo.sh
+++ b/updateGo.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Function to print usage
 usage() {
@@ -12,7 +13,7 @@ check_for_updates() {
   git fetch
 
   LOCAL=$(git rev-parse @)
-  REMOTE=$(git rev-parse @{u} 2>/dev/null)
+  REMOTE=$(git rev-parse @{u} 2>/dev/null || echo "")
   if [ -z $REMOTE ]; then
     echo "No updates to this script available on this branch"
     return
@@ -119,4 +120,5 @@ source $PROFILE_FILE
 
 # Step 5: Verify the installation
 echo "Verifying the Go installation..."
-go version && echo "Go ${VERSION} has been installed successfully."
+go version
+echo "Go ${VERSION} has been installed successfully."

--- a/updateGo.sh
+++ b/updateGo.sh
@@ -100,7 +100,7 @@ echo "Extracting Go ${VERSION} to /usr/local..."
 sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
 
 # Step 4: Update PATH environment variable
-echo "Updating PATH to include /usr/local/go/bin..."
+echo "Updating PATH to include /usr/local/go/bin and ~/go/bin..."
 PROFILE_FILE=""
 
 if [ "$OS" = "darwin" ]; then
@@ -115,6 +115,9 @@ fi
 
 if ! grep -q 'export PATH=$PATH:/usr/local/go/bin' $PROFILE_FILE; then
   echo 'export PATH=$PATH:/usr/local/go/bin' >> $PROFILE_FILE
+fi
+if ! grep -q 'export PATH=$PATH:~/go/bin' $PROFILE_FILE; then
+  echo 'export PATH=$PATH:~/go/bin' >> $PROFILE_FILE
 fi
 source $PROFILE_FILE
 


### PR DESCRIPTION
You can see an explanation of `set -euo pipefail` with `set --help` or https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425.

The ` || echo ""` has been added because `git rev-parse @{u}` exits with status code 128 on branches with no remote.

~/go/bin is where `go install` puts binaries of tools such as https://go.dev/doc/tutorial/govulncheck. The path `~/go` should be returned by the command `/usr/local/go/bin/go env GOPATH`, if ever needed in the future.