### PR TITLE
Fix all warnings & suggestions from shellcheck

### DIFF
--- a/updateGo.sh
+++ b/updateGo.sh
@@ -13,13 +13,13 @@ check_for_updates() {
   git fetch
 
   LOCAL=$(git rev-parse @)
-  REMOTE=$(git rev-parse @{u} 2>/dev/null || echo "")
-  if [ -z $REMOTE ]; then
+  REMOTE=$(git rev-parse '@{u}' 2>/dev/null || echo "")
+  if [ -z "$REMOTE" ]; then
     echo "No updates to this script available on this branch"
     return
   fi
 
-  if [ $LOCAL != $REMOTE ]; then
+  if [ "$LOCAL" != "$REMOTE" ]; then
     echo "There are updates available for this script. Do you want to update? (y/n)"
     read -r response
     if [[ "$response" == "y" || "$response" == "Y" ]]; then
@@ -80,7 +80,7 @@ check_for_updates
 
 # Step 1: Attempt to download the specified version of Go
 echo "Downloading Go version ${VERSION} from ${URL}..."
-wget $URL -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
+wget "$URL" -O "/tmp/go${VERSION}.${OS}-${ARCH}.tar.gz"
 WGET_RESULT=$?
 if [ $WGET_RESULT != 0 ]; then
   echo "Error: wget exited with code ${WGET_RESULT}" >&2
@@ -97,7 +97,7 @@ fi
 
 # Step 3: Extract the downloaded tarball to /usr/local
 echo "Extracting Go ${VERSION} to /usr/local..."
-sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
+sudo tar -C /usr/local -xzf "/tmp/go${VERSION}.${OS}-${ARCH}.tar.gz"
 
 # Step 4: Update PATH environment variable
 echo "Updating PATH to include /usr/local/go/bin and ~/go/bin..."
@@ -113,12 +113,13 @@ else
   PROFILE_FILE=~/.profile
 fi
 
-if ! grep -q 'export PATH=$PATH:/usr/local/go/bin' $PROFILE_FILE; then
-  echo 'export PATH=$PATH:/usr/local/go/bin' >> $PROFILE_FILE
+if ! grep -q "export PATH=\$PATH:/usr/local/go/bin" $PROFILE_FILE; then
+  echo "export PATH=\$PATH:/usr/local/go/bin" >> $PROFILE_FILE
 fi
-if ! grep -q 'export PATH=$PATH:~/go/bin' $PROFILE_FILE; then
-  echo 'export PATH=$PATH:~/go/bin' >> $PROFILE_FILE
+if ! grep -q "export PATH=\$PATH:~/go/bin" $PROFILE_FILE; then
+  echo "export PATH=\$PATH:~/go/bin" >> $PROFILE_FILE
 fi
+# shellcheck source=/dev/null
 source $PROFILE_FILE
 
 # Step 5: Verify the installation


### PR DESCRIPTION
https://github.com/koalaman/shellcheck

Before these changes, here was shellcheck's output:

    $ shellcheck updateGo.sh

    In updateGo.sh line 16:
      REMOTE=$(git rev-parse @{u} 2>/dev/null || echo "")
                              ^-- SC1083 (warning): This { is literal. Check expression (missing ;/\n?) or quote it.
                                ^-- SC1083 (warning): This } is literal. Check expression (missing ;/\n?) or quote it.

    In updateGo.sh line 17:
      if [ -z $REMOTE ]; then
              ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean:
      if [ -z "$REMOTE" ]; then

    In updateGo.sh line 22:
      if [ $LOCAL != $REMOTE ]; then
          ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                    ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean:
      if [ "$LOCAL" != "$REMOTE" ]; then

    In updateGo.sh line 83:
    wget $URL -O /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
        ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.
                        ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean:
    wget "$URL" -O /tmp/go"${VERSION}".${OS}-${ARCH}.tar.gz

    In updateGo.sh line 100:
    sudo tar -C /usr/local -xzf /tmp/go${VERSION}.${OS}-${ARCH}.tar.gz
                                      ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

    Did you mean:
    sudo tar -C /usr/local -xzf /tmp/go"${VERSION}".${OS}-${ARCH}.tar.gz

    In updateGo.sh line 116:
    if ! grep -q 'export PATH=$PATH:/usr/local/go/bin' $PROFILE_FILE; then
                ^-- SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.

    In updateGo.sh line 117:
      echo 'export PATH=$PATH:/usr/local/go/bin' >> $PROFILE_FILE
          ^-- SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.

    In updateGo.sh line 119:
    if ! grep -q 'export PATH=$PATH:~/go/bin' $PROFILE_FILE; then
                ^--------------------------^ SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.

    In updateGo.sh line 120:
      echo 'export PATH=$PATH:~/go/bin' >> $PROFILE_FILE
          ^--------------------------^ SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.

    In updateGo.sh line 122:
    source $PROFILE_FILE
          ^-----------^ SC1090 (warning): ShellCheck can't follow non-constant source. Use a directive to specify location.

    For more information:
      https://www.shellcheck.net/wiki/SC1083 -- This { is literal. Check expressi...
      https://www.shellcheck.net/wiki/SC1090 -- ShellCheck can't follow non-const...
      https://www.shellcheck.net/wiki/SC2016 -- Expressions don't expand in singl...