### PR TITLE
Append a patch version of ".0" if one is not given

### DIFF
--- a/updateGo.sh
+++ b/updateGo.sh
@@ -73,6 +73,11 @@ case $ARCH in
     ;;
 esac
 
+# Ensure VERSION includes a patch version because Go's API requires it
+if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    VERSION="${VERSION}.0"
+fi
+
 URL="https://go.dev/dl/go${VERSION}.${OS}-${ARCH}.tar.gz"
 
 # Check for updates to the script


### PR DESCRIPTION
Go's API requires a patch version. This change allows the user to enter a version like `1.26` to install Go 1.26.0 instead of getting this unclear error message:

```
$ ,update-go linux amd64 1.26
The script is up to date.
Downloading Go version 1.26 from https://go.dev/dl/go1.26.linux-amd64.tar.gz...
--2026-02-10 14:00:37--  https://go.dev/dl/go1.26.linux-amd64.tar.gz
Resolving go.dev (go.dev)... 216.239.32.21, 216.239.38.21, 216.239.34.21, ...
Connecting to go.dev (go.dev)|216.239.32.21|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://dl.google.com/go/go1.26.linux-amd64.tar.gz [following]
--2026-02-10 14:00:37--  https://dl.google.com/go/go1.26.linux-amd64.tar.gz
Resolving dl.google.com (dl.google.com)... 142.250.72.238, 2607:f8b0:4007:814::200e
Connecting to dl.google.com (dl.google.com)|142.250.72.238|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2026-02-10 14:00:37 ERROR 404: Not Found.
```